### PR TITLE
FIX rollback to old google drive version libraries

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 certifi==2018.8.24
 chardet==3.0.4
-gspread==3.0.1
+gspread==0.6.2
 httplib2==0.11.3
 idna==2.7
-oauth2client==4.1.3
+oauth2client==4.1.2
 pkg-resources==0.0.0
 pyasn1==0.4.4
 pyasn1-modules==0.2.2

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,2 +1,2 @@
-gspread
-oauth2client
+gspread==0.6.2
+oauth2client==4.1.2


### PR DESCRIPTION
This two libraries need to be rolled back in order to make the current code work.
Changes in the code would needed to use the latest version, this would be addressed in issue #9